### PR TITLE
Fix: update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22

### DIFF
--- a/lib_runtime_fastrand.go
+++ b/lib_runtime_fastrand.go
@@ -1,0 +1,10 @@
+//go:build !go1.22
+
+package zenq
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname Fastrand runtime.fastrand
+func Fastrand() uint32

--- a/lib_runtime_fastrand_1.22.go
+++ b/lib_runtime_fastrand_1.22.go
@@ -1,0 +1,10 @@
+//go:build go1.22
+
+package zenq
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname Fastrand runtime.cheaprand
+func Fastrand() uint32

--- a/lib_runtime_linkage.go
+++ b/lib_runtime_linkage.go
@@ -41,9 +41,6 @@ func goparkunlock(lock *mutex, reason waitReason, traceEv byte, traceskip int)
 // defined in the asm files
 func GetG() unsafe.Pointer
 
-//go:linkname Fastrand runtime.fastrand
-func Fastrand() uint32
-
 //go:linkname Fastlog2 runtime.fastlog2
 func Fastlog2(x float64) float64
 


### PR DESCRIPTION
update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22


In Golang 1.22, the `runtime.fastrand` method was renamed to `cheaprand`. This commit updates all occurrences of `runtime.fastrand` in the project to use the new `cheaprand` method to maintain compatibility with the latest Golang version and address performance concerns.

Refer: https://gist.github.com/Aoang/3dc06f127f3f54507b7e06b7b6550c28